### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ CUSFが公開しているサイト(https://predict.sondehub.org/ )を自団体�
 サイトの中身は以下のリンクから確認できます！
 https://wasa-rockoon.github.io/Falling-position-simulator/
 
+## GitHub Pagesでの公開
+このリポジトリでは GitHub Actions を利用して GitHub Pages に自動デプロイされます。
+main ブランチに push するとワークフローが実行され、最新のファイルが公開されます。
+リポジトリの Settings > Pages で「Build and deployment」→「Source」を "GitHub Actions" に設定してください。
+
 ##　Upcoming Feature
 今後自分が実装したいものを記入していきます。
 ・ガス計算シートの実装


### PR DESCRIPTION
## Summary
- configure GitHub Actions to publish static site to GitHub Pages
- document GitHub Pages deployment instructions in README

## Testing
- `python test.py & sleep 1; kill $!` *(starts server and is terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5a0c4ed483239af4925bbd952db3